### PR TITLE
ft/address memory consumption during inference

### DIFF
--- a/src/dotnetANPR/Extensions/BitmapExtensions.cs
+++ b/src/dotnetANPR/Extensions/BitmapExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
 
 namespace dotnetANPR.Extensions;
 
@@ -20,36 +22,53 @@ internal static class BitmapExtensions
     {
         var kernelSize = (int)Math.Sqrt(kernel.Length);
         var kernelOffset = kernelSize / 2;
+        var width = image.Width;
+        var height = image.Height;
 
-        var result = new Bitmap(image.Width, image.Height);
+        var result = new Bitmap(width, height, PixelFormat.Format24bppRgb);
+        var rect = new Rectangle(0, 0, width, height);
 
-        for (var y = 0; y < image.Height; y++)
+        // Lock source as 24bppRgb (GDI+ converts if needed); lock dest for writing
+        var srcData = image.LockBits(rect, ImageLockMode.ReadOnly, PixelFormat.Format24bppRgb);
+        var dstData = result.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format24bppRgb);
+
+        var stride = srcData.Stride; // same for both since both are 24bppRgb
+        var srcBytes = new byte[Math.Abs(stride) * height];
+        var dstBytes = new byte[Math.Abs(stride) * height];
+
+        Marshal.Copy(srcData.Scan0, srcBytes, 0, srcBytes.Length);
+
+        for (var y = 0; y < height; y++)
         {
-            for (var x = 0; x < image.Width; x++)
+            for (var x = 0; x < width; x++)
             {
-                float r = 0, g = 0, b = 0;
+                float sumR = 0, sumG = 0, sumB = 0;
 
                 for (var ky = -kernelOffset; ky <= kernelOffset; ky++)
                 {
                     for (var kx = -kernelOffset; kx <= kernelOffset; kx++)
                     {
-                        var px = Clamp(x + kx, 0, image.Width - 1);
-                        var py = Clamp(y + ky, 0, image.Height - 1);
+                        var px = Clamp(x + kx, 0, width - 1);
+                        var py = Clamp(y + ky, 0, height - 1);
+                        var kv = kernel[ky + kernelOffset, kx + kernelOffset];
+                        var srcIdx = py * stride + px * 3;
 
-                        var pixel = image.GetPixel(px, py);
-                        r += pixel.R * kernel[ky + kernelOffset, kx + kernelOffset];
-                        g += pixel.G * kernel[ky + kernelOffset, kx + kernelOffset];
-                        b += pixel.B * kernel[ky + kernelOffset, kx + kernelOffset];
+                        sumB += srcBytes[srcIdx]     * kv; // B
+                        sumG += srcBytes[srcIdx + 1] * kv; // G
+                        sumR += srcBytes[srcIdx + 2] * kv; // R
                     }
                 }
 
-                r = Clamp(r, 0, 255);
-                g = Clamp(g, 0, 255);
-                b = Clamp(b, 0, 255);
-
-                result.SetPixel(x, y, Color.FromArgb((int)r, (int)g, (int)b));
+                var dstIdx = y * stride + x * 3;
+                dstBytes[dstIdx]     = (byte)Clamp((int)sumB, 0, 255); // B
+                dstBytes[dstIdx + 1] = (byte)Clamp((int)sumG, 0, 255); // G
+                dstBytes[dstIdx + 2] = (byte)Clamp((int)sumR, 0, 255); // R
             }
         }
+
+        Marshal.Copy(dstBytes, 0, dstData.Scan0, dstBytes.Length);
+        image.UnlockBits(srcData);
+        result.UnlockBits(dstData);
 
         return result;
     }

--- a/src/dotnetANPR/ImageAnalysis/Band.cs
+++ b/src/dotnetANPR/ImageAnalysis/Band.cs
@@ -28,6 +28,7 @@ public class Band(Bitmap image) : Photo(image)
             _graphHandle.RankFilter(Image.Height);
             _graphHandle.ApplyProbabilityDistributor(Distributor);
             _graphHandle.FindPeaks(NumberOfCandidates);
+            image.Dispose(); // histogram is built; release the working bitmap
         }
 
         return _graphHandle.Peaks;
@@ -94,5 +95,8 @@ public class Band(Bitmap image) : Photo(image)
                 sum += GetBrightness(i2, x, y);
                 SetBrightness(source, x, y, Math.Min(1f, sum));
             }
+
+        i1.Dispose();
+        i2.Dispose();
     }
 }

--- a/src/dotnetANPR/ImageAnalysis/CarSnapshot.cs
+++ b/src/dotnetANPR/ImageAnalysis/CarSnapshot.cs
@@ -67,8 +67,10 @@ public class CarSnapshot(Bitmap image) : Photo(image)
     {
         if (_graphHandle == null)
         {
-            var imageCopy = DuplicateBitmap(Image);
-            imageCopy = VerticalEdge(imageCopy);
+            var raw = DuplicateBitmap(Image);
+            var imageCopy = VerticalEdge(raw); // Convolve returns a new Bitmap
+            raw.Dispose();                     // release the DuplicateBitmap
+
             Thresholding(imageCopy);
             writer?.Write("vertical-rank-filter", imageCopy);
 
@@ -76,6 +78,7 @@ public class CarSnapshot(Bitmap image) : Photo(image)
             _graphHandle.RankFilter(CarSnapshotGraphRankFilter);
             _graphHandle.ApplyProbabilityDistributor(Distributor);
             _graphHandle.FindPeaks(NumberOfCandidates); // sort by height
+            imageCopy.Dispose(); // histogram is built; release the working bitmap
         }
 
         return _graphHandle.Peaks;

--- a/src/dotnetANPR/ImageAnalysis/Character.cs
+++ b/src/dotnetANPR/ImageAnalysis/Character.cs
@@ -70,13 +70,32 @@ public class Character : Photo
         Image = ThresholdedImage;
         var pixelMap = PixelMap;
         var bestPiece = pixelMap.BestPiece();
-        colorImage = BestPieceInFullColor(colorImage, bestPiece);
+
+        // Crop to the best piece region if it has valid dimensions
+        Bitmap statsImage;
+        bool ownStatsImage;
+        if (bestPiece.Width > 0 && bestPiece.Height > 0)
+        {
+            statsImage = colorImage.SubImage(
+                bestPiece.MostLeftPoint, bestPiece.MostTopPoint,
+                bestPiece.Width, bestPiece.Height);
+            ownStatsImage = true;
+        }
+        else
+        {
+            statsImage = colorImage;
+            ownStatsImage = false;
+        }
 
         // Compute statistics
-        ComputeStatisticBrightness(colorImage);
-        ComputeStatisticContrast(colorImage);
-        ComputeStatisticHue(colorImage);
-        ComputeStatisticSaturation(colorImage);
+        ComputeStatisticBrightness(statsImage);
+        ComputeStatisticContrast(statsImage);
+        ComputeStatisticHue(statsImage);
+        ComputeStatisticSaturation(statsImage);
+
+        if (ownStatsImage)
+            statsImage.Dispose();
+        colorImage.Dispose();
 
         Image = bestPiece.Render() ?? new Bitmap(1, 1, PixelFormat.Format24bppRgb);
 
@@ -147,14 +166,6 @@ public class Character : Photo
     {
         directoryName = directoryName.TrimEnd('/');
         return directoryName.Substring(directoryName.LastIndexOf('_'));
-    }
-
-    private Bitmap BestPieceInFullColor(Bitmap bi, PixelMap.Piece piece)
-    {
-        if (piece.Width <= 0 || piece.Height <= 0)
-            return bi;
-
-        return bi.SubImage(piece.MostLeftPoint, piece.MostTopPoint, piece.Width, piece.Height);
     }
 
     private void NormalizeResizeOnly()

--- a/src/dotnetANPR/ImageAnalysis/Photo.cs
+++ b/src/dotnetANPR/ImageAnalysis/Photo.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
 using dotnetANPR.Configuration;
 
 namespace dotnetANPR.ImageAnalysis;
@@ -91,14 +92,14 @@ public class Photo(Bitmap image) : IDisposable, ICloneable
         var rgbValues = new byte[bytes];
 
         // Copy the RGB values into the array
-        System.Runtime.InteropServices.Marshal.Copy(ptr, rgbValues, 0, bytes);
+        Marshal.Copy(ptr, rgbValues, 0, bytes);
 
         // Apply the thresholding
-        for (var i = 0; i < rgbValues.Length; i++) 
+        for (var i = 0; i < rgbValues.Length; i++)
             rgbValues[i] = threshold[rgbValues[i]];
 
         // Copy the RGB values back to the bitmap
-        System.Runtime.InteropServices.Marshal.Copy(rgbValues, 0, ptr, bytes);
+        Marshal.Copy(rgbValues, 0, ptr, bytes);
 
         // Unlock the bits
         bitmap.UnlockBits(bmpData);
@@ -107,9 +108,23 @@ public class Photo(Bitmap image) : IDisposable, ICloneable
     public static Bitmap ArrayToBitmap(float[,] array, int w, int h)
     {
         var bitmap = new Bitmap(w, h, PixelFormat.Format24bppRgb);
-        for (var x = 0; x < w; x++)
+        var rect = new Rectangle(0, 0, w, h);
+        var bmpData = bitmap.LockBits(rect, ImageLockMode.WriteOnly, PixelFormat.Format24bppRgb);
+        var stride = bmpData.Stride;
+        var pixelBytes = new byte[stride * h];
+
         for (var y = 0; y < h; y++)
-            SetBrightness(bitmap, x, y, array[x, y]);
+            for (var x = 0; x < w; x++)
+            {
+                var b = (byte)(array[x, y] * 255);
+                var offset = y * stride + x * 3;
+                pixelBytes[offset]     = b; // B
+                pixelBytes[offset + 1] = b; // G
+                pixelBytes[offset + 2] = b; // R
+            }
+
+        Marshal.Copy(pixelBytes, 0, bmpData.Scan0, pixelBytes.Length);
+        bitmap.UnlockBits(bmpData);
         return bitmap;
     }
 
@@ -149,9 +164,19 @@ public class Photo(Bitmap image) : IDisposable, ICloneable
 
     #region Filters
 
-    public void LinearResize(int width, int height) { image = LinearResizeImage(image, width, height); }
+    public void LinearResize(int width, int height)
+    {
+        var newImage = LinearResizeImage(image, width, height);
+        image.Dispose();
+        image = newImage;
+    }
 
-    public void AverageResize(int width, int height) { image = AverageResizeImage(image, width, height); }
+    public void AverageResize(int width, int height)
+    {
+        var newImage = AverageResizeImage(image, width, height);
+        image.Dispose();
+        image = newImage;
+    }
 
     public Bitmap AverageResizeImage(Bitmap origin, int width, int height)
     {
@@ -275,7 +300,7 @@ public class Photo(Bitmap image) : IDisposable, ICloneable
         var width = image.Width;
         var height = image.Height;
         var sourceArray = BitmapToArray(image, width, height);
-        var destinationArray = BitmapToArray(image, width, height);
+        var destinationArray = new float[width, height]; // starts all-zero; filled below
 
         for (var x = 0; x < width; x++)
         for (var y = 0; y < height; y++)
@@ -292,7 +317,7 @@ public class Photo(Bitmap image) : IDisposable, ICloneable
                 }
 
             neighborhood /= count;
-            destinationArray[x, y] = destinationArray[x, y] < neighborhood ? 0f : 1f;
+            destinationArray[x, y] = sourceArray[x, y] < neighborhood ? 0f : 1f;
         }
 
         image = ArrayToBitmap(destinationArray, width, height);

--- a/src/dotnetANPR/ImageAnalysis/PixelMap.cs
+++ b/src/dotnetANPR/ImageAnalysis/PixelMap.cs
@@ -8,7 +8,7 @@ namespace dotnetANPR.ImageAnalysis;
 
 public class PixelMap
 {
-    private static bool[,] _matrix = null!;
+    private bool[,] _matrix = null!;
     private Piece? _bestPiece;
     private int _width;
     private int _height;
@@ -28,7 +28,7 @@ public class PixelMap
     public Piece BestPiece()
     {
         ReduceOtherPieces();
-        return _bestPiece ?? [];
+        return _bestPiece ?? new Piece(_matrix);
     }
 
     public PixelMap Skeletonize()
@@ -277,7 +277,7 @@ public class PixelMap
 
     private Piece CreatePiece(PointSet unsorted)
     {
-        Piece piece = [];
+        var piece = new Piece(_matrix);
         PointSet stack = [];
         stack.Push(unsorted.Last());
         while (stack.Any())
@@ -362,6 +362,13 @@ public class PixelMap
 
     public class Piece : PointSet
     {
+        private readonly bool[,] _matrix;
+
+        public Piece(bool[,] matrix)
+        {
+            _matrix = matrix;
+        }
+
         public int MostLeftPoint { get; set; }
 
         public int MostRightPoint { get; set; }

--- a/src/dotnetANPR/ImageAnalysis/Plate.cs
+++ b/src/dotnetANPR/ImageAnalysis/Plate.cs
@@ -57,24 +57,48 @@ public class Plate : Photo, ICloneable
 
     public void Normalize(StageWriter? writer = null)
     {
-        var clone1 = (Plate)Clone();
-        clone1.Image = clone1.VerticalEdgeDetector(clone1.Image);
-        writer?.Write("plate-vertical-edge", clone1.Image);
+        // Vertical edge — create a temporary Bitmap for edge detection only (no Plate clone needed)
+        var verticalEdgeBitmap = VerticalEdgeDetector(Image);
+        writer?.Write("plate-vertical-edge", verticalEdgeBitmap);
 
-        var vertical = clone1.HistogramYaxis(clone1.Image);
+        var vertical = HistogramYaxis(verticalEdgeBitmap);
+        verticalEdgeBitmap.Dispose();
+
+        var oldImage = Image;
         Image = CutTopBottom(Image, vertical);
-        _plateCopy!.Image = CutTopBottom(_plateCopy.Image, vertical);
+        oldImage.Dispose();
+
+        var oldPlateCopyImage = _plateCopy!.Image;
+        _plateCopy.Image = CutTopBottom(_plateCopy.Image, vertical);
+        oldPlateCopyImage.Dispose();
         writer?.Write("plate-cut-top-bottom", Image);
 
-        var clone2 = (Plate)Clone();
+        // Horizontal edge — similarly avoid cloning the Plate
+        Bitmap horizontalEdgeBitmap;
+        bool disposeHorizontalEdge;
         if (HorizontalDetectionType == 1)
-            clone2.Image = clone2.HorizontalEdgeDetector(clone2.Image);
+        {
+            horizontalEdgeBitmap = HorizontalEdgeDetector(Image);
+            disposeHorizontalEdge = true;
+        }
+        else
+        {
+            horizontalEdgeBitmap = Image; // borrow reference; no ownership transfer
+            disposeHorizontalEdge = false;
+        }
+        writer?.Write("plate-horizontal-edge", horizontalEdgeBitmap);
 
-        writer?.Write("plate-horizontal-edge", clone2.Image);
+        var horizontal = HistogramXAxis(horizontalEdgeBitmap);
+        if (disposeHorizontalEdge)
+            horizontalEdgeBitmap.Dispose();
 
-        var horizontal = clone1.HistogramXAxis(clone2.Image);
+        oldImage = Image;
         Image = CutLeftRight(Image, horizontal);
+        oldImage.Dispose();
+
+        oldPlateCopyImage = _plateCopy.Image;
         _plateCopy.Image = CutLeftRight(_plateCopy.Image, horizontal);
+        oldPlateCopyImage.Dispose();
         writer?.Write("plate-normalized", Image);
     }
 

--- a/src/dotnetANPR/Intelligence/Intelligence.cs
+++ b/src/dotnetANPR/Intelligence/Intelligence.cs
@@ -40,14 +40,20 @@ public class Intelligence
                 // Skew detection runs when either configured or dumping stages
                 if (skewDetectionMode != 0 || stageWriter != null)
                 {
-                    var notNormalizedCopy = (Plate)plate.Clone();
-                    notNormalizedCopy.Image = notNormalizedCopy.HorizontalEdgeDetector(notNormalizedCopy.Image);
-                    var hough = notNormalizedCopy.GetHoughTransformation();
+                    // HorizontalEdgeDetector reads plate.Image and returns a new Bitmap —
+                    // no need to clone the whole Plate (which would also duplicate _plateCopy).
+                    using var edgeBitmap = plate.HorizontalEdgeDetector(plate.Image);
+
+                    // Build the Hough transform directly from the edge bitmap
+                    var hough = new HoughTransformation(edgeBitmap.Width, edgeBitmap.Height);
+                    for (var hx = 0; hx < edgeBitmap.Width; hx++)
+                        for (var hy = 0; hy < edgeBitmap.Height; hy++)
+                            hough.AddLine(hx, hy, Photo.GetBrightness(edgeBitmap, hx, hy));
 
                     if (stageWriter != null)
                     {
-                        stageWriter.Write("skew-horizontal-edge", notNormalizedCopy.Image);
-                        var renderedHoughTransform = hough.Render(HoughTransformation.RenderType.RenderAll,
+                        stageWriter.Write("skew-horizontal-edge", edgeBitmap);
+                        using var renderedHoughTransform = hough.Render(HoughTransformation.RenderType.RenderAll,
                             HoughTransformation.ColorType.BlackAndWhite);
                         stageWriter.Write("hough-transform", renderedHoughTransform);
                     }


### PR DESCRIPTION
### Type of PR (e.g feature, fix e.t.c):

fix

### Additional Details (i.e. what does this PR add?):

This PR fixes large memory consumption during number plate inference due to image copying 

BEFORE

<img width="774" height="482" alt="image" src="https://github.com/user-attachments/assets/d17bcf50-8a76-4057-8e18-229c81205d68" />

AFTER

<img width="774" height="437" alt="image" src="https://github.com/user-attachments/assets/db1134ca-d584-45e1-a3ea-faf1ed8b52e0" />


